### PR TITLE
Do not rewrite access modifier if fileprivate

### DIFF
--- a/Sources/IBOutletRewriterCore/Common/Extensions.swift
+++ b/Sources/IBOutletRewriterCore/Common/Extensions.swift
@@ -54,7 +54,7 @@ extension ModifierListSyntax {
         } else if let privateSetModifier = self.first(where: { $0.name.tokenKind == .privateKeyword }), privateSetModifier.detail?.reduce(into: "", { result, token in result += token.text }) == "(set)" {
             // private(set) -> private
             return self.replacing(childAt: privateSetModifier.indexInParent, with: privateModifier)
-        } else if self.contains(where: { $0.name.tokenKind == .privateKeyword }) {
+        } else if self.contains(where: { [.privateKeyword, .fileprivateKeyword].contains($0.name.tokenKind) }) {
             // private
             return self
         } else {

--- a/Tests/IBOutletRewriterCoreTests/VariableDeclRewriterTests.swift
+++ b/Tests/IBOutletRewriterCoreTests/VariableDeclRewriterTests.swift
@@ -12,78 +12,106 @@ import XCTest
 final class VariableDeclRewriterTests: XCTestCase {
     
     func testRewriteVariableDecl() {
-        let inputs = [
-            """
-            class View {
-                @IBOutlet var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet internal var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet private var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet private(set) var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet public var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet weak var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet internal weak var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet private weak var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet private(set) weak var view: UIView!
-            }
-            """,
-            """
-            class View {
-                @IBOutlet public weak var view: UIView!
-            }
-            """,
+        let testFixture: [(inputs: [String], expected: String)] = [
+            (
+                // to private
+                inputs: [
+                    """
+                    class View {
+                        @IBOutlet var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet internal var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet private var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet private(set) var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet public var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet weak var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet internal weak var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet private weak var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet private(set) weak var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet public weak var view: UIView!
+                    }
+                    """,
+                ],
+                expected:
+                """
+                class View {
+                    @IBOutlet private weak var view: UIView!
+                }
+                """
+            ),
+            (
+                // to fileprivate
+                inputs: [
+                    """
+                    class View {
+                        @IBOutlet fileprivate var view: UIView!
+                    }
+                    """,
+                    """
+                    class View {
+                        @IBOutlet fileprivate weak var view: UIView!
+                    }
+                    """
+                ],
+                expected:
+                """
+                class View {
+                    @IBOutlet fileprivate weak var view: UIView!
+                }
+                """
+            )
         ]
         
-        let expected = """
-        class View {
-            @IBOutlet private weak var view: UIView!
-        }
-        """
-        
-        inputs.forEach { input in
-            let filePathURL = createSourceFile(from: input)
-            defer {
-                delete(filePathURL: filePathURL)
-            }
-            
-            do {
-                let parser = SourceFileParser(pathURL: filePathURL)
-                let sourceFileSyntax = try parser.parse()
-                let output = VariableDeclRewriter().visit(sourceFileSyntax)
-                XCTAssertEqual(output.description, expected)
-            } catch let error {
-                fatalError("error: \(error)")
+        testFixture.forEach { inputs, expected in
+            inputs.forEach { input in
+                let filePathURL = createSourceFile(from: input)
+                defer {
+                    delete(filePathURL: filePathURL)
+                }
+
+                do {
+                    let parser = SourceFileParser(pathURL: filePathURL)
+                    let sourceFileSyntax = try parser.parse()
+                    let output = VariableDeclRewriter().visit(sourceFileSyntax)
+                    XCTAssertEqual(output.description, expected)
+                } catch let error {
+                    fatalError("error: \(error)")
+                }
             }
         }
     }


### PR DESCRIPTION
## Overview

Found a bug for `fileprivate`: https://github.com/kitasuke/IBOutletRewriter/issues/3

No rewriting if `fileprivate`