### PR TITLE
Use SPM steps on Bitrise

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,32 +7,27 @@ trigger_map:
   workflow: primary
 - pull_request_source_branch: "*"
   workflow: primary
+- tag: "*"
+  workflow: primary
 workflows:
   primary:
     steps:
     - activate-ssh-key@4.0.3:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4.0.14: {}
-    - script@1.1.5:
-        title: Do anything with Script step
+    - git::https://github.com/kitasuke/bitrise-step-swift-package-manager-build-for-mac.git@master:
         inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            # debug log
-            set -x
-
-            # write your script here
-            swift test --parallel
-            swift package generate-xcodeproj --enable-code-coverage
-
-            # or run a script from your repository, like:
-            # bash ./path/to/script.sh
-            # not just bash, e.g.:
-            # ruby ./path/to/script.rb
+        - build_tests: 'yes'
+    - git::https://github.com/kitasuke/bitrise-step-swift-package-manager-test-for-mac.git@master:
+        inputs:
+        - is_parallel: 'yes'
+        - is_skip_build: 'yes'
+    - git::https://github.com/kitasuke/bitrise-step-swift-package-manager-xcodeproj-for-mac.git@master:
+        inputs:
+        - enable_code_coverage: 'yes'
     - xcode-test-mac@1.2.1:
         inputs:
+        - is_clean_build: 'no'
         - output_tool: xcodebuild
         - generate_code_coverage_files: 'yes'
     - codecov@1.1.5:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,14 +15,14 @@ workflows:
     - activate-ssh-key@4.0.3:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4.0.14: {}
-    - git::https://github.com/kitasuke/bitrise-step-swift-package-manager-build-for-mac.git@master:
+    - swift-package-manager-build-for-mac@0.0.1:
         inputs:
         - build_tests: 'yes'
-    - git::https://github.com/kitasuke/bitrise-step-swift-package-manager-test-for-mac.git@master:
+    - swift-package-manager-test-for-mac@0.0.1:
         inputs:
         - is_parallel: 'yes'
         - is_skip_build: 'yes'
-    - git::https://github.com/kitasuke/bitrise-step-swift-package-manager-xcodeproj-for-mac.git@master:
+    - swift-package-manager-xcodeproj-for-mac@0.0.1:
         inputs:
         - enable_code_coverage: 'yes'
     - xcode-test-mac@1.2.1:


### PR DESCRIPTION
## Overview

Bitrise doesn't provide steps for SPM based project yet, so I created them by myself.

## Changes

- [x] `swift build` -> https://github.com/kitasuke/bitrise-step-swift-package-manager-build-for-mac
- [x] `swift test` -> https://github.com/kitasuke/bitrise-step-swift-package-manager-test-for-mac
- [x] `swift package generate-xcodeproj` -> https://github.com/kitasuke/bitrise-step-swift-package-manager-xcodeproj-for-mac

## TODO

- [x] Waiting to be merged into bitrise-steplibs
- [x] Replace steps with official step id 